### PR TITLE
Fix testlog link

### DIFF
--- a/RevolveTestDiaryXf/Models/EnvSetup.cs
+++ b/RevolveTestDiaryXf/Models/EnvSetup.cs
@@ -7,5 +7,6 @@ namespace RevolveTestDiaryXf.Models
     public class EnvSetup
     {
         public string OpenweatherKey { get; set; }
+        public string TestLogBaseUrl { get; set; }
     }
 }

--- a/RevolveTestDiaryXf/RevolveTestDiaryXf.csproj
+++ b/RevolveTestDiaryXf/RevolveTestDiaryXf.csproj
@@ -7,7 +7,7 @@
     <StartupObject>RevolveTestDiaryXf.Program</StartupObject>
     <PackageIcon></PackageIcon>
     <PackageIconUrl />
-    <Version>5.0.0</Version>
+    <Version>5.0.1</Version>
     <PackageId></PackageId>
     <Authors>Revolve NTNU</Authors>
     <Company>Revolve NTNU</Company>

--- a/RevolveTestDiaryXf/ViewModels/MainWindowViewModel.cs
+++ b/RevolveTestDiaryXf/ViewModels/MainWindowViewModel.cs
@@ -70,6 +70,7 @@ namespace RevolveTestDiaryXf.ViewModels
         }
 
         private string _dialogText;
+        private string _testLogBaseUrl;
 
         public string DialogText
         {
@@ -83,6 +84,7 @@ namespace RevolveTestDiaryXf.ViewModels
         {
             var envSetup = JsonSerializer.Deserialize<EnvSetup>(File.ReadAllText(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), @"Resources/setup.env")));
             _trackWeatherService = new TrackWeatherService(envSetup.OpenweatherKey);
+            _testLogBaseUrl = envSetup.TestLogBaseUrl;
             Locations = new ObservableCollection<string>(_trackWeatherService.TownToCoordMap.Keys);
             Location = Locations.FirstOrDefault();
 
@@ -211,7 +213,7 @@ namespace RevolveTestDiaryXf.ViewModels
             var content = new FormUrlEncodedContent(data);
             try
             {
-                var response = await client.PostAsync("http://vault.revolve.no/testlog/register/exterallog/", content);
+                var response = await client.PostAsync($"{_testLogBaseUrl}testlog/register/exterallog/", content);
                 var status = response.StatusCode;
                 if (status == HttpStatusCode.Created)
                 {


### PR DESCRIPTION
Added a TestLogBaseUrl to the configuration file, and included this in the build. Note that the setup.env file isnt included in this repository. Not sure how to best approach this. It contains an openweathermap API key, which is the "issue"

I see that this project is poorly architected (I was a noob a year ago). It could do with a few more services to keep the ViewModel clean. I will do that/describe it in an issue for someone else to do this week.